### PR TITLE
fix: sleep(uint16_t t) is too fast in 1T mode (#2)

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -87,7 +87,7 @@ uint16_t pow(uint8_t x, uint8_t y)
 ******************************************************************************/
 uint16_t _sleep_getInitValue(void)
 {
-    return (uint16_t)(MCU_FRE_CLK/(float)12000/8) - 2;
+    return (uint16_t)(MCU_FRE_CLK/(float)1000/5) - 18;
 }
 
 /*****************************************************************************/
@@ -103,16 +103,15 @@ uint16_t _sleep_getInitValue(void)
 void _sleep_1ms(void)
 {
     __asm
-        mov ar5, r6                 ;#2
+        push ar6                    ;low
+        push ar7                    ;high
+        inc  ar7
     delay1ms_loop$:
-        nop                         ;#1
-        nop                         ;#1
-        nop                         ;#1
-        nop                         ;#1
-        nop                         ;#1
-        nop                         ;#1
-        djnz r5, delay1ms_loop$     ;#2
-        ret                         ;#2
+        djnz ar6,delay1ms_loop$
+        djnz ar7,delay1ms_loop$
+        pop ar7
+        pop ar6
+        ret
     __endasm;
 }
 
@@ -163,14 +162,11 @@ void sleep(uint16_t t)
     ; loop for sleep
     ; loop from (0xFFFF - t) to (0xFFFF)
     LOOP$:
-        lcall __sleep_1ms               ;#8*(frep/12000) - 10
+        lcall __sleep_1ms               ;#5*(ar7*(256 + 1) + ar6)
         inc dptr                        ;#2
         mov a,dpl                       ;#1
         anl a,dph                       ;#1
         cpl a                           ;#1
-        nop                             ;#1
-        nop                             ;#1
-        nop                             ;#1
         jnz LOOP$                       ;#2
     ENDL$:
         pop ar7

--- a/src/util.c
+++ b/src/util.c
@@ -167,6 +167,7 @@ void sleep(uint16_t t)
         mov a,dpl                       ;#1
         anl a,dph                       ;#1
         cpl a                           ;#1
+        nop                             ;#1
         jnz LOOP$                       ;#2
     ENDL$:
         pop ar7


### PR DESCRIPTION
I have made a fix for this and tested it with oscillators of 11.0592MHz, 12MHz and 22.1184MHz, the error is less than 0.5% in all three cases. Please review.
